### PR TITLE
mkcolrv0: rename copyright string correctly

### DIFF
--- a/mkcolrv0.py
+++ b/mkcolrv0.py
@@ -11,6 +11,8 @@ def rename(args):
             rec.string = str(rec) + " " + args.suffix
         elif rec.nameID in (3, 6):
             rec.string = str(rec) + args.suffix
+        elif rec.nameID == 0:
+            rec.string = str(rec).replace("Kufi", f"Kufi {args.suffix}")
         elif "-" in str(rec):
             string = str(rec).split("-")
             rec.string = "-".join([string[0] + args.suffix] + string[1:])


### PR DESCRIPTION
Copyright string for Reem Kufi Fun is currently:
`Copyright 2015Fun-2022 The Reem Kufi Project Authors (https://github.com/aliftype/reem-kufi).`

This PR fixes the misplaced suffix so we get:
`Copyright 2015-2022 The Reem Kufi Fun Project Authors (https://github.com/aliftype/reem-kufi).`